### PR TITLE
Fixes error with removing xinmo-juyao directory

### DIFF
--- a/apply_updates.sh
+++ b/apply_updates.sh
@@ -121,7 +121,7 @@ sudo cp -rf ./opt/retropie/supplementary/splashscreen/asplashscreen.sh /opt/retr
 sudo cp ./etc/profile.d/10-retropie.sh /etc/profile.d/10-retropie.sh.VM
 sudo cp -rf ./etc/profile.d/10-retropie.sh /etc/profile.d/10-retropie.sh
 # 2020-07-03 PlayBox xinmo, USB-Extend, BGM, Samba core scripts fixes-enhancements by 2play!
-rm -R /home/pi/RetroPie/extras+/xinmo-juyao/
+rm -R /home/pi/RetroPie/extras+/xinmo-juyao
 cp -rf ./home/pi/RetroPie/retropiemenu/Emulation/xinmo-juyao.sh /home/pi/RetroPie/retropiemenu/Emulation/xinmo-juyao.sh
 cp -rf ./home/pi/RetroPie/extras+/.pb-fixes/retropiemenu/Emulation/xinmo-juyao.sh /home/pi/RetroPie/extras+/.pb-fixes/retropiemenu/Emulation/xinmo-juyao.sh
 cp -rf ./opt/retropie/configs/all/autostart.sh /opt/retropie/configs/all/autostart.sh

--- a/apply_updates.sh
+++ b/apply_updates.sh
@@ -121,7 +121,7 @@ sudo cp -rf ./opt/retropie/supplementary/splashscreen/asplashscreen.sh /opt/retr
 sudo cp ./etc/profile.d/10-retropie.sh /etc/profile.d/10-retropie.sh.VM
 sudo cp -rf ./etc/profile.d/10-retropie.sh /etc/profile.d/10-retropie.sh
 # 2020-07-03 PlayBox xinmo, USB-Extend, BGM, Samba core scripts fixes-enhancements by 2play!
-rm -R /home/pi/RetroPie/extras+/xinmo-juyao
+rm -R -f /home/pi/RetroPie/extras+/xinmo-juyao
 cp -rf ./home/pi/RetroPie/retropiemenu/Emulation/xinmo-juyao.sh /home/pi/RetroPie/retropiemenu/Emulation/xinmo-juyao.sh
 cp -rf ./home/pi/RetroPie/extras+/.pb-fixes/retropiemenu/Emulation/xinmo-juyao.sh /home/pi/RetroPie/extras+/.pb-fixes/retropiemenu/Emulation/xinmo-juyao.sh
 cp -rf ./opt/retropie/configs/all/autostart.sh /opt/retropie/configs/all/autostart.sh


### PR DESCRIPTION
Removes trailing forward-slash to quiet `rm: cannot remove '/home/pi/RetroPie/extras+/xinmo-juyao/': Not a directory` error