### PR TITLE
Adds fix for ScummVM saves directory

### DIFF
--- a/apply_updates.sh
+++ b/apply_updates.sh
@@ -223,7 +223,9 @@ sudo chown pi:pi -R /etc/emulationstation/themes/
 cp -rf ./home/pi/RetroPie/roms/ports/snap/*.mp4 /home/pi/RetroPie/roms/ports/snap/
 # 2020-09-03 - PC Dosbox fixed Stunts now launching, updated autoexec.bat - reported by @Sunrise169 and fixed by @VirtualMan
 cp -rf ./home/pi/RetroPie/roms/pc/Stunts/*.* /home/pi/RetroPie/roms/pc/Stunts/
-
+# 2020-09-04 - ScummVM save file directory fix - reported and fixed by @Thrillho
+sed -i 's|savefile_directory = "~/RetroPie/saves/saturn"|savefile_directory = "~/RetroPie/saves/scummvm"|g' /opt/retropie/configs/scummvm/retroarch.cfg
+sed -i 's|savestate_directory = "~/RetroPie/saves/saturn/states"|savestate_directory = "~/RetroPie/saves/scummvm/states"|g' /opt/retropie/configs/scummvm/retroarch.cfg
 
 # 2020-04-29 sleep and force reboot - VMAN!
 sleep 10


### PR DESCRIPTION
Adds a fix to replace `saturn` with `scummvm` in `/opt/retropie/configs/scummvm/retroarch.cfg`